### PR TITLE
refactor: cleaning up file management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _build
 build
 cmake-build-debug
 cmake-build-release
+cmake-build-debug-visual-studio
+cmake-build-release-visual-studio
 out
 
 # Just for testing video, please remove later.

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -10,7 +10,7 @@ namespace utilities {
 
 constexpr std::string_view hexwave_project_ext = ".hexw";
 
-#ifndef WIN32
+#ifndef _WIN32
 /**
  * @brief Linux File Reader.
  *
@@ -42,15 +42,33 @@ public:
 };
 #endif
 
+/**
+ * @brief Save the current project
+ *
+ * @param manager The video manager with the videos.
+ *
+ * @return bool true if project was able to save
+ */
 bool save_project(video_manager& manager);
 
+/**
+ * @brief Load a project.
+ *
+ * @brief The video manager to load the videos to.
+ *
+ * @return bool true if project was loaded successfully.
+ */
 bool load_project(video_manager& manager);
 
 /**
  * @brief Opens a file prompt to retrieve a file path.
  *
+ * @param is_save Is this prompt a save prompt?
+ * @param title The title of the prompt.
+ * @param linux_filters Filters for Linux (usually formatted as `name | filter`)
+ * @param windows_filters Filters for Windows (usually formatted as `name\0filter\0name\0filter\0`)
  *
- * @return
+ * @return std::string File path (includes file name, for example `/opt/hexwave/testing.hexw`
  */
 std::string get_file_from_prompt(const bool is_save, const std::string& title, const std::string& linux_filters, const char* windows_filters);
 }

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -2,10 +2,39 @@
 
 #include "video_manager.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace utilities {
+
+#ifndef WIN32
+/**
+ * @brief Linux File Reader.
+ *
+ * @note linux_file will automatically close and free up memory when it is no longer required.
+ */
+struct linux_file {
+	FILE* f;
+
+	operator FILE *() {return f;}
+
+	~linux_file() {
+		pclose(f);
+		f = nullptr;
+	};
+};
+#endif
 
 bool save_project(video_manager& manager);
 
 bool load_project(video_manager& manager);
 
+/**
+ * @brief Opens a file prompt to retrieve a file path.
+ *
+ *
+ * @return
+ */
+std::string get_file_from_prompt(const bool is_save, const std::string_view title, const std::vector<std::string_view>& filters);
 }

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -50,5 +50,5 @@ bool load_project(video_manager& manager);
  *
  * @return
  */
-std::string get_file_from_prompt(const bool is_save, const std::string& title, const std::vector<std::pair<std::string_view, std::string_view>>& filters = {});
+std::string get_file_from_prompt(const bool is_save, const std::string& title, const std::string& linux_filters, const char* windows_filters);
 }

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -8,6 +8,8 @@
 
 namespace utilities {
 
+constexpr std::string_view hexwave_project_ext = ".hexw";
+
 #ifndef WIN32
 /**
  * @brief Linux File Reader.

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -14,14 +14,28 @@ namespace utilities {
  *
  * @note linux_file will automatically close and free up memory when it is no longer required.
  */
-struct linux_file {
-	FILE* f;
+class linux_file {
+	FILE* f{nullptr};
+
+public:
+	linux_file() = default;
+	linux_file(FILE *file) : f{file} {}
+	linux_file(const linux_file&) = delete;
+	linux_file(linux_file&& other) noexcept : f{std::exchange(other.f, nullptr)} {}
+
+	linux_file &operator=(const linux_file&) = delete;
+	linux_file &operator=(linux_file&& other) noexcept {
+		f = std::exchange(other.f, nullptr);
+		return *this;
+	}
 
 	operator FILE *() {return f;}
 
 	~linux_file() {
-		pclose(f);
-		f = nullptr;
+		if(f != nullptr) {
+			pclose(f);
+			f = nullptr;
+		}
 	};
 };
 #endif
@@ -36,5 +50,5 @@ bool load_project(video_manager& manager);
  *
  * @return
  */
-std::string get_file_from_prompt(const bool is_save, const std::string_view title, const std::vector<std::string_view>& filters);
+std::string get_file_from_prompt(const bool is_save, const std::string_view title, const std::vector<std::string_view>& filters = {});
 }

--- a/include/engine/utilities/file_management.h
+++ b/include/engine/utilities/file_management.h
@@ -50,5 +50,5 @@ bool load_project(video_manager& manager);
  *
  * @return
  */
-std::string get_file_from_prompt(const bool is_save, const std::string_view title, const std::vector<std::string_view>& filters = {});
+std::string get_file_from_prompt(const bool is_save, const std::string& title, const std::vector<std::pair<std::string_view, std::string_view>>& filters = {});
 }

--- a/include/engine/utilities/input_manager.h
+++ b/include/engine/utilities/input_manager.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/engine/utilities/file_management.cpp
+++ b/src/engine/utilities/file_management.cpp
@@ -101,7 +101,11 @@ std::string utilities::get_file_from_prompt(const bool is_save, const std::strin
 	ofn.lpstrInitialDir = nullptr;
 	ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
-	GetOpenFileName(&ofn);
+	if(is_save) {
+		GetSaveFileName(&ofn);
+	} else {
+		GetOpenFileName(&ofn);
+	}
 
 #endif
 

--- a/src/engine/utilities/file_management.cpp
+++ b/src/engine/utilities/file_management.cpp
@@ -14,6 +14,7 @@ bool utilities::save_project(video_manager& manager) {
 
 	// Does filename NOT end in ".hexw"?
 	if(filename.compare(filename.size() - hexwave_project_ext.size(), hexwave_project_ext.size(), hexwave_project_ext) != 0) {
+		// because file doesn't end in ".hexw", we need to add ".hexw" to it to ensure all files end in that.
 		filename.append(hexwave_project_ext);
 	}
 

--- a/src/engine/utilities/file_management.cpp
+++ b/src/engine/utilities/file_management.cpp
@@ -6,10 +6,15 @@
 
 bool utilities::save_project(video_manager& manager) {
 
-	std::string filename{get_file_from_prompt(true, "Save Project", "*.hexw", "Hexwave Project\0*.hexw\0")};
+	std::string filename{get_file_from_prompt(true, "Save Project", "Hexwave Project | *.hexw", "Hexwave Project\0*.hexw\0")};
 
 	if(filename.empty()) {
 		return false;
+	}
+
+	// Does filename NOT end in ".hexw"?
+	if(filename.compare(filename.size() - hexwave_project_ext.size(), hexwave_project_ext.size(), hexwave_project_ext) != 0) {
+		filename.append(hexwave_project_ext);
 	}
 
 	json j;
@@ -30,7 +35,7 @@ bool utilities::save_project(video_manager& manager) {
 
 bool utilities::load_project(video_manager& manager) {
 
-	std::string filename{get_file_from_prompt(false, "Open Project", "*.hexw", "Hexwave Project\0*.hexw\0")};
+	std::string filename{get_file_from_prompt(false, "Open Project", "Hexwave Project | *.hexw", "Hexwave Project\0*.hexw\0")};
 
 	if(filename.empty()) {
 		return false;
@@ -76,7 +81,7 @@ std::string utilities::get_file_from_prompt(const bool is_save, const std::strin
 
 #ifndef _WIN32 // !_WIN32
 
-	std::string clause("zenity --file-selection" + std::string(is_save ? " --save" : "") + " --title=" + title + " --file-filter='" + linux_filters + "'");
+	std::string clause("zenity --file-selection" + std::string(is_save ? " --save" : "") + " --title=" + title + " --file-filter='" + linux_filters + "' --file-filter='All | *.*'");
 
 	linux_file f{popen(clause.c_str(), "r")};
 

--- a/src/engine/utilities/file_management.cpp
+++ b/src/engine/utilities/file_management.cpp
@@ -3,10 +3,6 @@
 #include <vector>
 #include "utilities/file_management.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 bool utilities::save_project(video_manager& manager) {
 
 	char filename[1024];
@@ -72,43 +68,9 @@ bool utilities::save_project(video_manager& manager) {
 
 bool utilities::load_project(video_manager& manager) {
 
-	char filename[1024];
+	std::string& filename ==
 
-	// Linux only, will ALWAYS be false on Windows.
-	bool file_fail{ false };
-
-#ifndef _WIN32 // !_WIN32
-
-	FILE* f = popen(R"(zenity --file-selection --title="Open project" --file-filter=*.hexw)", "r");
-
-	// Might be possible to just not use fgets, should look into this.
-	// Will be true if fgets is nullptr (invalid).
-	file_fail = (fgets(filename, 1024, f) == nullptr);
-
-	pclose(f);
-	f = nullptr;
-
-#else // _WIN32
-
-	OPENFILENAME ofn{};
-
-	ofn.lStructSize = sizeof(ofn);
-	ofn.hwndOwner = NULL;
-	ofn.lpstrFile = filename;
-	ofn.lpstrFile[0] = '\0';
-	ofn.nMaxFile = sizeof(filename);
-	ofn.lpstrFilter = "Hexwave Project\0*.hexw\0All\0*.*\0";
-	ofn.nFilterIndex = 1;
-	ofn.lpstrFileTitle = NULL;
-	ofn.nMaxFileTitle = 0;
-	ofn.lpstrInitialDir = NULL;
-	ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
-
-	GetOpenFileName(&ofn);
-
-#endif
-
-	if (file_fail || std::strlen(filename) == 0) {
+	if (file_fail || ) {
 		return false;
 	}
 
@@ -149,4 +111,51 @@ bool utilities::load_project(video_manager& manager) {
 	}
 
 	return true;
+}
+
+std::string utilities::get_file_from_prompt(const bool is_save, const std::string_view title,
+					    const std::vector<std::string_view> &filters) {
+	char filename[1024];
+
+	// Linux only, will ALWAYS be false on Windows.
+	bool file_fail{ false };
+
+#ifndef _WIN32 // !_WIN32
+
+	linux_file f = popen(R"(zenity --file-selection --title="Open project" --file-filter=*.hexw)", "r");
+
+	// Might be possible to just not use fgets, should look into this.
+	// Will be true if fgets is nullptr (invalid).
+	file_fail = (fgets(filename, 1024, f) == nullptr);
+
+#else // _WIN32
+
+	OPENFILENAME ofn{};
+
+	ofn.lStructSize = sizeof(ofn);
+	ofn.hwndOwner = nullptr;
+	ofn.lpstrFile = filename;
+	ofn.lpstrFile[0] = '\0';
+	ofn.nMaxFile = sizeof(filename);
+	ofn.lpstrFilter = "Hexwave Project\0*.hexw\0All\0*.*\0";
+	ofn.nFilterIndex = 1;
+	ofn.lpstrFileTitle = nullptr;
+	ofn.nMaxFileTitle = 0;
+	ofn.lpstrInitialDir = nullptr;
+	ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+
+	GetOpenFileName(&ofn);
+
+#endif
+
+	if(file_fail || std::strlen(filename) == 0) {
+		return "";
+	}
+
+	auto len = std::strlen(filename);
+	if (len > 0 && filename[len - 1] == '\n') {
+		filename[len - 1] = 0;
+	}
+
+	return filename;
 }

--- a/src/engine/utilities/file_management.cpp
+++ b/src/engine/utilities/file_management.cpp
@@ -6,7 +6,7 @@
 
 bool utilities::save_project(video_manager& manager) {
 
-	std::string filename{get_file_from_prompt(true, "Save Project", { {"Hexwave Project", "*.hexw"} })};
+	std::string filename{get_file_from_prompt(true, "Save Project", "*.hexw", "Hexwave Project\0*.hexw\0")};
 
 	if(filename.empty()) {
 		return false;
@@ -30,7 +30,7 @@ bool utilities::save_project(video_manager& manager) {
 
 bool utilities::load_project(video_manager& manager) {
 
-	std::string filename{get_file_from_prompt(false, "Open Project", { {"Hexwave Project", "*.hexw"} })};
+	std::string filename{get_file_from_prompt(false, "Open Project", "*.hexw", "Hexwave Project\0*.hexw\0")};
 
 	if(filename.empty()) {
 		return false;
@@ -71,20 +71,12 @@ bool utilities::load_project(video_manager& manager) {
 }
 
 std::string utilities::get_file_from_prompt(const bool is_save, const std::string& title,
-					    const std::vector<std::pair<std::string_view, std::string_view>> &filters) {
+					    const std::string& linux_filters, const char* windows_filters) {
 	char filename[1024];
 
 #ifndef _WIN32 // !_WIN32
 
-	std::string filter{};
-
-	// Linux only needs the file type.
-	for(const auto& filt : filters) {
-		filter.append(filt.second);
-		filter.append("\0");
-	}
-
-	std::string clause("zenity --file-selection" + std::string(is_save ? " --save" : "") + " --title=" + title + " --file-filter='" + filter + "'");
+	std::string clause("zenity --file-selection" + std::string(is_save ? " --save" : "") + " --title=" + title + " --file-filter='" + linux_filters + "'");
 
 	linux_file f{popen(clause.c_str(), "r")};
 
@@ -96,18 +88,6 @@ std::string utilities::get_file_from_prompt(const bool is_save, const std::strin
 
 #else // _WIN32
 
-	std::string filter{};
-
-	// Windows requires both title and file type.
-	for(const auto& filt : filters) {
-		filter.append(filt.first);
-		filter.append("\0");
-		filter.append(filt.second);
-		filter.append("\0");
-	}
-
-	filter.append("All\0*.*\0");
-
 	OPENFILENAME ofn{};
 
 	ofn.lStructSize = sizeof(ofn);
@@ -115,7 +95,7 @@ std::string utilities::get_file_from_prompt(const bool is_save, const std::strin
 	ofn.lpstrFile = filename;
 	ofn.lpstrFile[0] = '\0';
 	ofn.nMaxFile = sizeof(filename);
-	ofn.lpstrFilter = filter.c_str();
+	ofn.lpstrFilter = windows_filters;
 	ofn.nFilterIndex = 1;
 	ofn.lpstrFileTitle = nullptr;
 	ofn.nMaxFileTitle = 0;

--- a/src/engine/utilities/input_manager.cpp
+++ b/src/engine/utilities/input_manager.cpp
@@ -1,0 +1,1 @@
+#include "utilities/input_manager.h"

--- a/src/engine/video_manager.cpp
+++ b/src/engine/video_manager.cpp
@@ -229,8 +229,7 @@ void video_manager::render_window(video_reader& reader) {
 			ImGui::SameLine();
 
 			if (ImGui::Button(std::string("Select Video").c_str())) {
-
-				std::string video_path{utilities::get_file_from_prompt(false, "Open Video File", { {"MP4", "*.mp4"}, {"MOV", "*.mov"}, {"WMV", "*.wmv"}, {"AVI", "*.avi"}, {"MKV", "*.mkv"}, {"WEBM", "*.webm"} })};
+				std::string video_path{utilities::get_file_from_prompt(false, "Open Video File", "*.mp4 | *.mov | *.wmv | *.avi | *.mkv | *.webm | *.*", "MP4\0*.mp4\0MOV\0*.mov\0WMV\0*.wmv\0AVI\0*.avi\0MKV\0*.mkv\0WEBM\0*.webm\0All\0*.*\0")};
 
 				std::ifstream video_file(video_path);
 

--- a/src/engine/video_manager.cpp
+++ b/src/engine/video_manager.cpp
@@ -53,19 +53,15 @@ void video_manager::add_option(video& vid, const std::string_view id, const std:
 	vid.options.emplace(id, opt);
 }
 
-static void testing() {
-	ImGui::OpenPopup("add_video_popup");
-}
-
 
 void video_manager::render_window(video_reader& reader) {
 	if(ImGui::Begin("Videos")) {
 		if (ImGui::Button("Add Video")) {
-			testing();
+			ImGui::OpenPopup("add_video_popup");
 		}
 		ImGui::SameLine();
 		if (ImGui::Button("Remove ALL Videos")) {
-			//remove_all_videos();
+			remove_all_videos();
 		}
 
 		static std::string vid_id_interacting_with;
@@ -236,7 +232,7 @@ void video_manager::render_window(video_reader& reader) {
 				if (video_file.good()) {
 					const char* temp_path = video_path.c_str();
 					// Copy temp path to path if the path was valid.
-					std::memcpy(path, temp_path, sizeof(temp_path));
+					std::memcpy(path, temp_path, std::strlen(temp_path));
 				} else {
 					ImGui::InsertNotification({ ImGuiToastType::Error, 3000, "Failed to open video file, please make sure it's a valid video!" });
 				}
@@ -565,7 +561,6 @@ bool video_manager::read_video_frame(GLFWwindow* window, video_reader* state, ui
 	}
 
 	uint8_t* dest[4] = { frame_buffer, NULL, NULL, NULL };
-	std::cout << "WIDTH BE LIKE: " << state->width << "\n";
 	int dest_linesize[4] = { state->width * 4, 0, 0, 0 };
 	sws_scale(state->sws_scaler_ctx, state->av_frame->data, state->av_frame->linesize, 0, state->height, dest, dest_linesize);
 

--- a/src/engine/video_manager.cpp
+++ b/src/engine/video_manager.cpp
@@ -225,7 +225,7 @@ void video_manager::render_window(video_reader& reader) {
 			ImGui::SameLine();
 
 			if (ImGui::Button(std::string("Select Video").c_str())) {
-				std::string video_path{utilities::get_file_from_prompt(false, "Open Video File", "*.mp4 | *.mov | *.wmv | *.avi | *.mkv | *.webm | *.*", "MP4\0*.mp4\0MOV\0*.mov\0WMV\0*.wmv\0AVI\0*.avi\0MKV\0*.mkv\0WEBM\0*.webm\0All\0*.*\0")};
+				std::string video_path{utilities::get_file_from_prompt(false, "Open Video File", "Video Files | *.mp4 *.mov *.wmv *.avi *.mkv *.webm", "MP4\0*.mp4\0MOV\0*.mov\0WMV\0*.wmv\0AVI\0*.avi\0MKV\0*.mkv\0WEBM\0*.webm\0All\0*.*\0")};
 
 				std::ifstream video_file(video_path);
 

--- a/src/engine/window.cpp
+++ b/src/engine/window.cpp
@@ -59,7 +59,7 @@ window::window() {
 
 
 	glfwSetKeyCallback(glfw_window, [](GLFWwindow* window, int key, int scancode, int action, int mods) {
-		std::cout << "key pressed: " << key << "\n";
+		//std::cout << "key pressed: " << key << "\n";
 		/*
 		if (action == GLFW_PRESS) {
 			if (key == GLFW_KEY_F11) {
@@ -175,7 +175,7 @@ void window::window_loop() {
 			int count;
 			const float* axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &count);
 
-			std::cout << "controller funnies: " << axes[0] << "\n";
+			//std::cout << "controller funnies: " << axes[0] << "\n";
 		}
 
 		//const auto& render_start = std::chrono::high_resolution_clock::now();

--- a/src/engine/window.cpp
+++ b/src/engine/window.cpp
@@ -57,17 +57,20 @@ window::window() {
 	glfwSetWindowIcon(glfw_window, 1, images);
 	stbi_image_free(images[0].pixels);
 
-	/*
+
 	glfwSetKeyCallback(glfw_window, [](GLFWwindow* window, int key, int scancode, int action, int mods) {
+		std::cout << "key pressed: " << key << "\n";
+		/*
 		if (action == GLFW_PRESS) {
 			if (key == GLFW_KEY_F11) {
 				glfw_window
 				glfwSetWindowSize(glfw_window, desktopWidth, desktopHeight);
 			}
 		}
+		 */
 		return;
 	});
-	*/
+
 
 	//  glfwSetWindowMonitor
 
@@ -167,6 +170,13 @@ void window::window_loop() {
 
 		static bool first_frame{ true };
 		static bool show_choices{ false };
+
+		if(glfwJoystickPresent(GLFW_JOYSTICK_1) == GLFW_TRUE) {
+			int count;
+			const float* axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &count);
+
+			std::cout << "controller funnies: " << axes[0] << "\n";
+		}
 
 		//const auto& render_start = std::chrono::high_resolution_clock::now();
 


### PR DESCRIPTION
This PR aims to clean up how the file manager works, reducing the amount of code copy pasted whilst also moving the `FILE* f = popen(...)` to use RAII. This will massively clean things up as the copy paste now carries over to the window file.